### PR TITLE
Remove duplicated plus signs

### DIFF
--- a/v1.2/source/bbk.f
+++ b/v1.2/source/bbk.f
@@ -156,7 +156,7 @@ c
             do j = 1, 3
                a(j,iglob) = -convert * derivs(j,i)/mass(iglob)
                v(j,iglob) = (v(j,iglob) +
-     $          +dt_2*a(j,iglob) + a2*Rn(j,i)/sqrt(mass(iglob)))/
+     $          dt_2*a(j,iglob) + a2*Rn(j,i)/sqrt(mass(iglob)))/
      $          (1+dt*gamma/2)
             end do
          end if


### PR DESCRIPTION
Note that previous versions also have duplicated signs:

https://github.com/TinkerTools/tinker-hp/blob/a3016e95d3a346962ac21b3f605ee27a3243a5f8/v1.1/source/bbk.f#L155-L156
https://github.com/TinkerTools/tinker-hp/blob/a3016e95d3a346962ac21b3f605ee27a3243a5f8/v1.1v/source/bbk.f#L155-L156