### PR TITLE
Add feature to print stress tensor components during MD

### DIFF
--- a/GPU/source/MOD_mdstuf.f
+++ b/GPU/source/MOD_mdstuf.f
@@ -16,6 +16,7 @@ c     bmnmix      mixing coefficient for use with Beeman integrator
 c     dorest      logical flag to remove center of mass inertia
 c     velsave     logical flag to save velocity vector components
 c     frcsave     logical flag to save force vector components
+c     stresave    logical flag to save stress tensor components
 c     uindsave    logical flag to save induced atomic dipoles
 c     integrate   type of molecular dynamics integration algorithm
 c
@@ -28,6 +29,7 @@ c
       logical dorest
       logical velsave
       logical frcsave
+      logical stresave
       logical uindsave
       logical mts
       character*20 integrate

--- a/GPU/source/mdinit.f
+++ b/GPU/source/mdinit.f
@@ -212,6 +212,13 @@ c         read (string,*,iostat=ios)  nfree
           frcsave = .true.
         case ('SAVE-INDUCED')
           uindsave = .true.
+        case ('SAVE-STRESS')
+          stresave = .true.
+          use_virial=.true.
+          verbose = .true.
+          write(*,*)
+     &    'SAVE-STRESS: The units of the stress tensor '// 
+     &    'components are Atmospheres'
         case ('THERMOSTAT')
           call getword (record,thermostat,next)
           call upcase (thermostat)

--- a/GPU/source/mdstat.f
+++ b/GPU/source/mdstat.f
@@ -227,6 +227,15 @@ c
                    write(iout,'(A)',advance="no") 
      &                         "       Pres"
                  endif
+                 if(stresave) then
+                   write(iout,'(A)',advance="no")
+     &                         "     Stress(xx)"
+     &                       //"     Stress(yy)"
+     &                       //"     Stress(zz)"
+     &                       //"     Stress(xy)"
+     &                       //"     Stress(yz)"
+     &                       //"     Stress(xz)"  
+                 endif      
 c                 if(isobaric) then
 c                   write(iout,'(A)',advance="no") 
 c     &                         "     Density"
@@ -242,6 +251,11 @@ c                 endif
      &             istep,etot,epot,ekin,temp
                if(use_virial) then
                  write(iout,'(f11.2)',advance="no") pres
+               endif
+               if(stresave) then
+                 write(iout,'(6f15.4)',advance="no") 
+     &                 stress(1,1),stress(2,2),stress(3,3),
+     &                 stress(1,2),stress(2,3),stress(1,3)
                endif
                !if(isobaric) then
                !  write(iout,'(f12.4,f12.2)',advance="no") dens,volbox

--- a/GPU/source/pressure.f
+++ b/GPU/source/pressure.f
@@ -21,6 +21,7 @@ c
       use bound
       use boxes
       use domdec
+      use mdstuf    ,only:stresave
       use tinheader ,only:ti_p,re_p
       use units
       use virial
@@ -34,14 +35,13 @@ c
       real(r_p) stres1,stres2,stres3
 c
 c     only necessary if periodic boundaries are in use
-c     and isobaric simulation
 c
       if (.not.(use_bounds.and.use_virial))  return
 c
 c     calculate the stress tensor for anisotropic systems
 c
       factor = prescon / volbox
-      if (anisotrop) then
+      if (anisotrop.or.stresave) then
 !$acc parallel loop collapse(2) default(present) async
         do i = 1, 3
            do j = 1, 3


### PR DESCRIPTION
# Summary

This pull request adds functionality to output the stress tensor alongside verbose output, enabling viscosity calculations using the Green-Kubo or Einstein relations.

## Details

- Introduces a new keyword:
   - `SAVE-STRESS` controls whether the stress tensor is written during MD simulation. 

- Writes components to the main output (`.out`) file as additional columns next to verbose out.

- Updates existing source files to integrate new functionality:
  - `MOD_mdstuf.f` includes new logical variable `stresave`.
  - `mdinit.f` checks if the `SAVE-STRESS` keyword is in the `.key` file.
  - `pressure.f` adds logic to calculate the stress tensor in NVT/NVE ensembles.
  - `mdstat.f` writes components to `.out` file.


## Sample Output

Appears in the `.out` file:

```
SAVE-STRESS: The units of the stress tensor components are Atmospheres

 --- Tinker-HP: loading restart file for EtOH_rep01 system ---

 Molecular Dynamics Trajectory via Velocity Verlet Algorithm
     MD Step     E total   E Potential     E Kinetic       Temp       Pres     Stress(xx)     Stress(yy)     Stress(zz)     Stress(xy)     Stress(yz)     Stress(xz)
         1     4052.2025    -3911.2297     7963.4322     296.87     -65.05      -505.6220      -377.1029       687.5805      -271.1346         9.4270        49.8107
         2     4047.1898    -3968.8755     8016.0652     298.84    -141.67       -85.8715      -595.8872       256.7504      -161.0730       337.0726       280.8896
         3     4043.7029    -4012.5023     8056.2053     300.33    -257.10       159.3216      -777.0220      -153.5985      -102.2136       467.6862       362.6684
         4     4045.1988    -3993.1576     8038.3564     299.67    -319.47       241.5343      -834.2966      -365.6566       -84.6812       354.1359       260.8619
         5     4050.1036    -3937.8502     7987.9538     297.79    -335.75       205.0718      -809.6037      -402.7269       -77.7163        92.4782        65.1255
```

## Performance

- Adds ~4% overhead.

##  Notes

Manuscript in preparation describing these modifications and a companion toolkit for viscosity calculations.

Happy to adjust anything to better align with project conventions. Thanks for your time and consideration.